### PR TITLE
Escaped Environment Variables in 'echo ... >> ~/.bashrc' command hinted in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ source $(activate-python-docker-run-shell-completion 2> /dev/null)
 > **Warning**  
 > Outside of a virtual environment, *pip* may default to a user-site installation of executables to `~/.local/bin`, which may not be present in your shell's `PATH`.  If running `docker-run` errors with `docker-run: command not found`, add the directory to your path. [*(More information)*](https://packaging.python.org/en/latest/tutorials/installing-packages/#installing-to-the-user-site)  
 > ```bash
-> echo "export PATH=$HOME/.local/bin:$PATH" >> ~/.bashrc
+> echo "export PATH=\$HOME/.local/bin:\$PATH" >> ~/.bashrc
 > source ~/.bashrc
 > ```
 


### PR DESCRIPTION
The previously suggested `echo "export PATH=$HOME/.local/bin:$PATH" >> ~/.bashrc` command will directly substitute the `$HOME` and `$PATH` variable when pasting into the .bashrc file. Especially substituting the latter variable can screw with one's PATH settings, as it will always set it to its current value, even after rebooting.

This PR escapes the environment variables using `\`, such that `export PATH=$HOME/.local/bin:$PATH` is now present in the .bashrc file.