### PR TITLE
Fix optional dependencies for pip<21.2

### DIFF
--- a/docker-run-cli/pyproject.toml
+++ b/docker-run-cli/pyproject.toml
@@ -28,9 +28,9 @@ requires-python = ">=3.7"
 
 [project.optional-dependencies]
 dev = ["build", "twine"]
-docker-ros = ["docker-run-docker-ros>=1.0.3"]
-plugins = ["docker-run-cli[docker-ros]"]
-all = ["docker-run-cli[plugins]", "docker-run-cli[dev]"]
+docker-ros = ["docker-run-docker-ros>=1.0.4"]
+plugins = ["docker-run-docker-ros>=1.0.4"]
+all = ["docker-run-docker-ros>=1.0.4", "build", "twine"]
 
 [project.urls]
 "Repository" = "https://github.com/ika-rwth-aachen/docker-run"

--- a/docker-run-cli/pyproject.toml
+++ b/docker-run-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docker-run-cli"
-version = "0.9.5"
+version = "0.9.6"
 description = "'docker run' and 'docker exec' with useful defaults"
 license = {file = "LICENSE"}
 readme = "README.md"

--- a/docker-run-cli/src/docker_run/__init__.py
+++ b/docker-run-cli/src/docker_run/__init__.py
@@ -1,2 +1,2 @@
 __name__ = "docker-run"
-__version__ = "0.9.5"
+__version__ = "0.9.6"


### PR DESCRIPTION
- pip supports recursive optional dependencies in `pyproject.toml` starting with v21.2 ([source](https://hynek.me/articles/python-recursive-optional-dependencies/))
- the change explicitly sets optional dependencies for now
- this fixes, e.g., `pip install docker-run-cli[plugins]` on pip<21.2