### PR TITLE
Fix locale issue if LC_ALL is unset

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,12 @@
 name: Publish to PyPI
 
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   publish:
@@ -20,12 +26,14 @@ jobs:
       run: python3 -m pip install --user build
     - name: Build wheel and tarball
       run: python3 -m build --sdist --wheel --outdir dist/ ${{ matrix.package }}
-    - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@v1.8.6
-      with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository-url: https://test.pypi.org/legacy/
-        skip-existing: true
+    # TestPyPI currently disabled cause `skip-existing: true` is not honored
+    # https://github.com/pypa/gh-action-pypi-publish/issues/201
+    # - name: Publish to TestPyPI
+    #   uses: pypa/gh-action-pypi-publish@v1.8.6
+    #   with:
+    #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+    #     repository-url: https://test.pypi.org/legacy/
+    #     skip-existing: true
     - name: Publish to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@v1.8.6

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Institute for Automotive Engineering (ika), RWTH Aachen University
+Copyright (c) 2023-2024 Institute for Automotive Engineering (ika), RWTH Aachen University
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docker-run-cli/pyproject.toml
+++ b/docker-run-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docker-run-cli"
-version = "0.9.7"
+version = "0.9.8"
 description = "'docker run' and 'docker exec' with useful defaults"
 license = {file = "LICENSE"}
 readme = "README.md"

--- a/docker-run-cli/src/docker_run/__init__.py
+++ b/docker-run-cli/src/docker_run/__init__.py
@@ -1,2 +1,2 @@
 __name__ = "docker-run"
-__version__ = "0.9.7"
+__version__ = "0.9.8"

--- a/docker-run-cli/src/docker_run/plugins/core.py
+++ b/docker-run-cli/src/docker_run/plugins/core.py
@@ -83,7 +83,7 @@ class CorePlugin(Plugin):
 
     @classmethod
     def localeFlags(cls) -> List[str]:
-        return ["--env LANG", "--env LANGUAGE", "--env LC_ALL"]
+        return ["--env LANG", "--env LANGUAGE", "--env LC_ALL=C"]
 
     @classmethod
     def gpuSupportFlags(cls) -> List[str]:


### PR DESCRIPTION
### Problem
- Ubuntu 22
- `echo $LC_ALL` prints nothing
- `docker-run gitlab.ika.rwth-aachen.de:5050/fb-fi/its-modules/monitoring/ros-monitoring` cannot start RViz
   ```
   dockeruser@8fa8e9f1e306:/docker-ros/ws$ rviz2
   QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-dockeruser'
   [INFO] [1718691638.738652173] [rviz2]: Stereo is NOT SUPPORTED
   [INFO] [1718691638.738745810] [rviz2]: OpenGl version: 4.5 (GLSL 4.5)
   terminate called after throwing an instance of 'std::runtime_error'
     what():  locale::facet::_S_create_c_locale name not valid
   Aborted (core dumped)
   ```

### Reason
- `--env LC_ALL` is added as part of `docker-run`
- `export LC_ALL=C` fixes the problem inside the container