### PR TITLE
Add support for up to Python 3.12 by replacing GPUtil with pynvml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,17 +29,16 @@ jobs:
     - name: Build wheel and tarball
       run: python3 -m build --sdist --wheel --outdir dist/ ${{ matrix.package }}
     - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@v1.8.6
+      uses: pypa/gh-action-pypi-publish@v1.12.4
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository-url: https://test.pypi.org/legacy/
         skip-existing: true
+        verbose: true
     - name: Publish to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@v1.8.6
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
         skip-existing: true
-    # `continue-on-error` needed cause `skip-existing: true` is not honored
-    # https://github.com/pypa/gh-action-pypi-publish/issues/201
-    continue-on-error: true
+        verbose: true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/github/license/ika-rwth-aachen/docker-run"/>
+  <a href="https://pypi.org/project/docker-run-cli/"><img src="https://img.shields.io/badge/python-v3.7--v3.12-blue.svg"/></a>
   <a href="https://pypi.org/project/docker-run-cli/"><img src="https://img.shields.io/pypi/v/docker-run-cli?label=PyPI"/></a>
   <a href="https://pypi.org/project/docker-run-cli/"><img src="https://img.shields.io/pypi/dm/docker-run-cli?color=blue&label=PyPI%20downloads"/></a>
 </p>

--- a/docker-run-cli/pyproject.toml
+++ b/docker-run-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docker-run-cli"
-version = "0.9.8"
+version = "0.9.9"
 description = "'docker run' and 'docker exec' with useful defaults"
 license = {file = "LICENSE"}
 readme = "README.md"
@@ -28,9 +28,9 @@ requires-python = ">=3.7"
 
 [project.optional-dependencies]
 dev = ["build", "twine"]
-docker-ros = ["docker-run-docker-ros>=1.0.5"]
-plugins = ["docker-run-docker-ros>=1.0.5"]
-all = ["docker-run-docker-ros>=1.0.5", "build", "twine"]
+docker-ros = ["docker-run-docker-ros>=1.0.6"]
+plugins = ["docker-run-docker-ros>=1.0.6"]
+all = ["docker-run-docker-ros>=1.0.6", "build", "twine"]
 
 [project.urls]
 "Repository" = "https://github.com/ika-rwth-aachen/docker-run"

--- a/docker-run-cli/pyproject.toml
+++ b/docker-run-cli/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
 ]
 keywords = ["docker", "container"]
-dependencies = ["GPUtil~=1.4.0"]
+dependencies = ["nvidia-ml-py~=12.570.86"]
 requires-python = ">=3.7"
 
 [project.optional-dependencies]

--- a/docker-run-cli/src/docker_run/__init__.py
+++ b/docker-run-cli/src/docker_run/__init__.py
@@ -1,2 +1,2 @@
 __name__ = "docker-run"
-__version__ = "0.9.8"
+__version__ = "0.9.9"

--- a/docker-run-cli/src/docker_run/plugins/core.py
+++ b/docker-run-cli/src/docker_run/plugins/core.py
@@ -87,13 +87,13 @@ class CorePlugin(Plugin):
 
     @classmethod
     def gpuSupportFlags(cls) -> List[str]:
-        has_gpu = True
+        n_gpus = 0
         try:
             pynvml.nvmlInit()
+            n_gpus = pynvml.nvmlDeviceGetCount()
         except pynvml.NVMLError:
-            has_gpu = False
-        has_gpu = has_gpu and (pynvml.nvmlDeviceGetCount() > 0)
-        if has_gpu:
+            pass
+        if n_gpus > 0:
             if cls.ARCH == "x86_64":
                 return ["--gpus all"]
             elif cls.ARCH == "aarch64" and cls.OS == "Linux":

--- a/docker-run-cli/src/docker_run/plugins/core.py
+++ b/docker-run-cli/src/docker_run/plugins/core.py
@@ -4,7 +4,7 @@ import platform
 import tempfile
 from typing import Any, Dict, List
 
-import GPUtil
+import pynvml
 
 from docker_run.utils import log, runCommand
 from docker_run.plugins.plugin import Plugin
@@ -87,7 +87,13 @@ class CorePlugin(Plugin):
 
     @classmethod
     def gpuSupportFlags(cls) -> List[str]:
-        if len(GPUtil.getGPUs()) > 0:
+        has_gpu = True
+        try:
+            pynvml.nvmlInit()
+        except pynvml.NVMLError:
+            has_gpu = False
+        has_gpu = has_gpu and (pynvml.nvmlDeviceGetCount() > 0)
+        if has_gpu:
             if cls.ARCH == "x86_64":
                 return ["--gpus all"]
             elif cls.ARCH == "aarch64" and cls.OS == "Linux":

--- a/docker-run-docker-ros/pyproject.toml
+++ b/docker-run-docker-ros/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docker-run-docker-ros"
-version = "1.0.5"
+version = "1.0.6"
 description = "docker-run plugin for Docker images built by docker-ros"
 license = {file = "LICENSE"}
 readme = "README.md"


### PR DESCRIPTION
- GPUtil broke Python 3.12 support, see https://github.com/anderskm/gputil/issues/53
- GPUtil is now replaced with [pynvml](https://pypi.org/project/nvidia-ml-py/) (for detection of GPUs)

#### Tested Python Support

| Arch | Version | w/o GPU | w/ GPU |
| --- | --- | --- | --- |
| amd64 | 3.7 | ✅ | ✅ |
| amd64 | 3.8 | ✅ | ✅ |
| amd64 | 3.9 | ✅ | ✅ |
| amd64 | 3.10 | ✅ | ✅ |
| amd64 | 3.11 | ✅ | ✅ |
| amd64 | 3.12 | ✅ | ✅ |
| arm64 | 3.7 |  | ✅ |
| arm64 | 3.8 |  | ✅ |
| arm64 | 3.9 |  | ✅ |
| arm64 | 3.10 |  | ✅ |
| arm64 | 3.11 |  | ✅ |
| arm64 | 3.12 | ✅ | ✅ |

FYI: @akloeker 