### PR TITLE
Fix locale flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ source $(activate-python-docker-run-shell-completion 2> /dev/null)
 ## Usage
 
 ```
-usage: docker-run [--help] [--image IMAGE] [--mwd] [--name NAME] [--no-gpu]
-                  [--no-it] [--no-loc] [--no-name] [--no-rm] [--no-tz]
+usage: docker-run [--help] [--image IMAGE] [--loc] [--mwd] [--name NAME]
+                  [--no-gpu] [--no-it] [--no-name] [--no-rm] [--no-tz]
                   [--no-x11] [--verbose] [--version]
 
 Executes `docker run` with the following features enabled by default, each of
@@ -93,16 +93,16 @@ forwarding. Passes any additional arguments to `docker run`. Executes `docker
 exec` instead if a container with the specified name (`--name`) is already
 running.
 
-optional arguments:
+options:
   --help         show this help message and exit
   --image IMAGE  image name (may also be specified without --image as last
                  argument before command)
+  --loc          enable automatic locale
   --mwd          mount current directory at same path
   --name NAME    container name; generates `docker exec` command if already
                  running
   --no-gpu       disable automatic GPU support
   --no-it        disable automatic interactive tty
-  --no-loc       disable automatic locale
   --no-name      disable automatic container name (current directory)
   --no-rm        disable automatic container removal
   --no-tz        disable automatic timezone

--- a/docker-run-cli/pyproject.toml
+++ b/docker-run-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docker-run-cli"
-version = "0.9.9"
+version = "0.10.0"
 description = "'docker run' and 'docker exec' with useful defaults"
 license = {file = "LICENSE"}
 readme = "README.md"
@@ -28,9 +28,9 @@ requires-python = ">=3.7"
 
 [project.optional-dependencies]
 dev = ["build", "twine"]
-docker-ros = ["docker-run-docker-ros>=1.0.6"]
-plugins = ["docker-run-docker-ros>=1.0.6"]
-all = ["docker-run-docker-ros>=1.0.6", "build", "twine"]
+docker-ros = ["docker-run-docker-ros>=1.0.7"]
+plugins = ["docker-run-docker-ros>=1.0.7"]
+all = ["docker-run-docker-ros>=1.0.7", "build", "twine"]
 
 [project.urls]
 "Repository" = "https://github.com/ika-rwth-aachen/docker-run"

--- a/docker-run-cli/src/docker_run/__init__.py
+++ b/docker-run-cli/src/docker_run/__init__.py
@@ -1,2 +1,2 @@
 __name__ = "docker-run"
-__version__ = "0.9.9"
+__version__ = "0.10.0"

--- a/docker-run-cli/src/docker_run/plugins/core.py
+++ b/docker-run-cli/src/docker_run/plugins/core.py
@@ -21,9 +21,9 @@ class CorePlugin(Plugin):
         parser.add_argument("--no-rm", action="store_true", help="disable automatic container removal")
         parser.add_argument("--no-it", action="store_true", help="disable automatic interactive tty")
         parser.add_argument("--no-tz", action="store_true", help="disable automatic timezone")
-        parser.add_argument("--no-loc", action="store_true", help="disable automatic locale")
         parser.add_argument("--no-gpu", action="store_true", help="disable automatic GPU support")
         parser.add_argument("--no-x11", action="store_true", help="disable automatic X11 GUI forwarding")
+        parser.add_argument("--loc", action="store_true", help="enable automatic locale")
         parser.add_argument("--mwd", action="store_true", help="mount current directory at same path")
 
     @classmethod
@@ -35,8 +35,6 @@ class CorePlugin(Plugin):
             flags += cls.interactiveFlags()
         if not args["no_tz"]:
             flags += cls.timezoneFlags()
-        if not args["no_loc"]:
-            flags += cls.localeFlags()
         if not args["no_gpu"]:
             flags += cls.gpuSupportFlags()
         if not args["no_x11"]:
@@ -46,6 +44,8 @@ class CorePlugin(Plugin):
                 if network_arg_index < len(unknown_args):
                     gui_forwarding_kwargs["docker_network"] = unknown_args[network_arg_index]
             flags += cls.x11GuiForwardingFlags(**gui_forwarding_kwargs)
+        if args["loc"]:
+            flags += cls.localeFlags()
         if args["mwd"]:
             flags += cls.currentDirMountFlags()
         return flags
@@ -83,7 +83,7 @@ class CorePlugin(Plugin):
 
     @classmethod
     def localeFlags(cls) -> List[str]:
-        return ["--env LANG", "--env LANGUAGE", "--env LC_ALL=C"]
+        return ["--env LANG", "--env LANGUAGE", "--env LC_ALL"]
 
     @classmethod
     def gpuSupportFlags(cls) -> List[str]:

--- a/docker-run-docker-ros/README.md
+++ b/docker-run-docker-ros/README.md
@@ -11,8 +11,8 @@ pip install docker-run[docker-ros]
 ## Usage
 
 ```
-usage: docker-run [--help] [--image IMAGE] [--mwd] [--mws] [--name NAME]
-                  [--no-gpu] [--no-it] [--no-loc] [--no-name] [--no-rm]
+usage: docker-run [--help] [--image IMAGE] [--loc] [--mwd] [--mws]
+                  [--name NAME] [--no-gpu] [--no-it] [--no-name] [--no-rm]
                   [--no-tz] [--no-user] [--no-x11] [--verbose] [--version]
 
 Executes `docker run` with the following features enabled by default, each of
@@ -22,10 +22,11 @@ forwarding. Passes any additional arguments to `docker run`. Executes `docker
 exec` instead if a container with the specified name (`--name`) is already
 running.
 
-optional arguments:
+options:
   --help         show this help message and exit
   --image IMAGE  image name (may also be specified without --image as last
                  argument before command)
+  --loc          enable automatic locale
   --mwd          mount current directory at same path
   --mws          [docker-ros] mount current directory into ROS workspace at
                  `/docker-ros/ws/src/target`
@@ -33,7 +34,6 @@ optional arguments:
                  running
   --no-gpu       disable automatic GPU support
   --no-it        disable automatic interactive tty
-  --no-loc       disable automatic locale
   --no-name      disable automatic container name (current directory)
   --no-rm        disable automatic container removal
   --no-tz        disable automatic timezone

--- a/docker-run-docker-ros/pyproject.toml
+++ b/docker-run-docker-ros/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docker-run-docker-ros"
-version = "1.0.6"
+version = "1.0.7"
 description = "docker-run plugin for Docker images built by docker-ros"
 license = {file = "LICENSE"}
 readme = "README.md"


### PR DESCRIPTION
- do not always pass `LC_ALL=C`, but rather rely on locale variables set in image
- invert `--no-loc` to `--loc` to explicitly enable passing of host variables `LANG`, `LANGUAGE`, and `LC_ALL`
- related to https://github.com/ika-rwth-aachen/docker-run/pull/10 and https://github.com/ika-rwth-aachen/docker-ros-ml-images/pull/18