### PR TITLE
Update gh-action-pypi-publish to v1.14.0 to fix GHSA-vxmw-7h4f-hqxh

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,16 +29,14 @@ jobs:
     - name: Build wheel and tarball
       run: python3 -m build --sdist --wheel --outdir dist/ ${{ matrix.package }}
     - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@v1.12.4
+      uses: pypa/gh-action-pypi-publish@v1.14.0
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository-url: https://test.pypi.org/legacy/
         skip-existing: true
-        verbose: true
     - name: Publish to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@v1.12.4
+      uses: pypa/gh-action-pypi-publish@v1.14.0
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
         skip-existing: true
-        verbose: true


### PR DESCRIPTION
https://github.com/pypa/gh-action-pypi-publish/security/advisories/GHSA-vxmw-7h4f-hqxh